### PR TITLE
Upgrade runtime to 6.8

### DIFF
--- a/io.github.lime3ds.Lime3DS.json
+++ b/io.github.lime3ds.Lime3DS.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.lime3ds.Lime3DS",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.7",
+    "runtime-version": "6.8",
     "sdk": "org.kde.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.llvm18"


### PR DESCRIPTION
The recently merged 2119 version adds Qt 6.8 support: https://github.com/Lime3DS/Lime3DS/pull/441