### PR TITLE
Updated Lime3DS source URL to point to Lime3DS archive repository

### DIFF
--- a/io.github.lime3ds.Lime3DS.json
+++ b/io.github.lime3ds.Lime3DS.json
@@ -144,7 +144,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/Lime3DS/Lime3DS/releases/download/2119.1/lime3ds-unified-source-2119.1.tar.xz",
+                    "url": "https://github.com/Lime3DS/lime3ds-archive/releases/download/2119.1/lime3ds-unified-source-2119.1.tar.xz",
                     "sha256": "1bd7be965f0b58e368556283c861082c25b971bc5c653d36ff3179e6df34541a"
                 },
                 {


### PR DESCRIPTION
Lime3DS is in the process of being superceded by another project has been discontinued and moved to a new repository in the transition.