### PR TITLE
Update KDE runtime to 6.8

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules

--- a/fix-build.patch
+++ b/fix-build.patch
@@ -1,0 +1,16 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 4f6ac50..10f4f74 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -115,11 +115,6 @@ else()
+         -fstack-clash-protection
+     )
+ 
+-    if (NOT CMAKE_BUILD_TYPE STREQUAL Debug)
+-        # _FORTIFY_SOURCE can't be used without optimizations.
+-        add_compile_options(-D_FORTIFY_SOURCE=2)
+-    endif()
+-
+     if (LIME3DS_WARNINGS_AS_ERRORS)
+         add_compile_options(-Werror)
+     endif()

--- a/io.github.lime3ds.Lime3DS.json
+++ b/io.github.lime3ds.Lime3DS.json
@@ -4,7 +4,7 @@
     "runtime-version": "6.8",
     "sdk": "org.kde.Sdk",
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.llvm19"
+        "org.freedesktop.Sdk.Extension.llvm18"
     ],
     "command": "lime3ds-launcher",
     "rename-desktop-file": "lime3ds.desktop",
@@ -15,8 +15,8 @@
     ],
     "copy-icon": true,
     "build-options": {
-        "append-path": "/usr/lib/sdk/llvm19/bin",
-        "prepend-ld-library-path": "/usr/lib/sdk/llvm19/lib",
+        "append-path": "/usr/lib/sdk/llvm18/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/llvm18/lib",
         "cflags": "-Wno-unused-command-line-argument",
         "cxxflags": "-Wno-unused-command-line-argument"
     },

--- a/io.github.lime3ds.Lime3DS.json
+++ b/io.github.lime3ds.Lime3DS.json
@@ -1,10 +1,10 @@
 {
     "app-id": "io.github.lime3ds.Lime3DS",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.7",
+    "runtime-version": "6.8",
     "sdk": "org.kde.Sdk",
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.llvm18"
+        "org.freedesktop.Sdk.Extension.llvm19"
     ],
     "command": "lime3ds-launcher",
     "rename-desktop-file": "lime3ds.desktop",
@@ -15,8 +15,8 @@
     ],
     "copy-icon": true,
     "build-options": {
-        "append-path": "/usr/lib/sdk/llvm18/bin",
-        "prepend-ld-library-path": "/usr/lib/sdk/llvm18/lib",
+        "append-path": "/usr/lib/sdk/llvm19/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/llvm19/lib",
         "cflags": "-Wno-unused-command-line-argument",
         "cxxflags": "-Wno-unused-command-line-argument"
     },
@@ -34,10 +34,6 @@
     ],
     "cleanup": [
         "/include",
-        "/bin/glslangValidator",
-        "/bin/glslang",
-        "/bin/spirv-*",
-        "/bin/sdl2-config",
         "/lib/pkgconfig",
         "/lib/cmake",
         "/share/doc",
@@ -47,50 +43,6 @@
         "*.la"
     ],
     "modules": [
-        {
-            "name": "glslang",
-            "buildsystem": "cmake-ninja",
-            "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/KhronosGroup/glslang/archive/15.0.0.tar.gz",
-                    "sha256": "c31c8c2e89af907507c0631273989526ee7d5cdf7df95ececd628fd7b811e064",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "stable-only": true,
-                        "project-id": 205796,
-                        "url-template": "https://github.com/KhronosGroup/glslang/archive/$version.tar.gz"
-                    }
-                },
-                {
-                    "type": "archive",
-                    "url": "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz",
-                    "sha256": "75aafdf7e731b4b6bfb36a590ddfbb38ebc605d80487f38254da24fe0cb95837",
-                    "dest": "External/spirv-tools",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "stable-only": true,
-                        "project-id": 334920,
-                        "url-template": "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/vulkan-sdk-$version.tar.gz"
-                    }
-                },
-                {
-                    "type": "archive",
-                    "url": "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz",
-                    "sha256": "1423d58a1171611d5aba2bf6f8c69c72ef9c38a0aca12c3493e4fda64c9b2dc6",
-                    "dest": "External/spirv-tools/external/spirv-headers",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "stable-only": true,
-                        "project-id": 334920,
-                        "url-template": "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-$version.tar.gz"
-                    }
-                }
-            ]
-        },
         {
             "name": "rapidjson",
             "buildsystem": "cmake-ninja",
@@ -154,6 +106,10 @@
                 {
                     "type": "file",
                     "path": "lime3ds-launcher.sh"
+                },
+                {
+                    "type": "patch",
+                    "path": "fix-build.patch"
                 }
             ]
         }


### PR DESCRIPTION
Lime3DS adds `-D_FORTIFY_SOURCE=2` to cflags, but the new runtime seems to use `-D_FORTIFY_SOURCE=3` by default, which leads to the build breaking because the flags are contradicting each other.

glslang is part of the runtime now