### PR TITLE
Remove all `x-checker-data` values

### DIFF
--- a/io.github.lime3ds.Lime3DS.json
+++ b/io.github.lime3ds.Lime3DS.json
@@ -57,37 +57,19 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/KhronosGroup/glslang/archive/15.0.0.tar.gz",
-                    "sha256": "c31c8c2e89af907507c0631273989526ee7d5cdf7df95ececd628fd7b811e064",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "stable-only": true,
-                        "project-id": 205796,
-                        "url-template": "https://github.com/KhronosGroup/glslang/archive/$version.tar.gz"
-                    }
+                    "sha256": "c31c8c2e89af907507c0631273989526ee7d5cdf7df95ececd628fd7b811e064"
                 },
                 {
                     "type": "archive",
                     "url": "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz",
                     "sha256": "75aafdf7e731b4b6bfb36a590ddfbb38ebc605d80487f38254da24fe0cb95837",
-                    "dest": "External/spirv-tools",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "stable-only": true,
-                        "project-id": 334920,
-                        "url-template": "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/vulkan-sdk-$version.tar.gz"
-                    }
+                    "dest": "External/spirv-tools"
                 },
                 {
                     "type": "archive",
                     "url": "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.3.296.0.tar.gz",
                     "sha256": "1423d58a1171611d5aba2bf6f8c69c72ef9c38a0aca12c3493e4fda64c9b2dc6",
-                    "dest": "External/spirv-tools/external/spirv-headers",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "stable-only": true,
-                        "project-id": 334920,
-                        "url-template": "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-$version.tar.gz"
-                    }
+                    "dest": "External/spirv-tools/external/spirv-headers"
                 }
             ]
         },
@@ -106,13 +88,7 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz",
-                    "sha256": "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "stable-only": true,
-                        "project-id": 7422,
-                        "url-template": "https://github.com/Tencent/rapidjson/archive/v$version.tar.gz"
-                    }
+                    "sha256": "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e"
                 }
             ]
         },


### PR DESCRIPTION
As Lime3DS is EOL, there is no reason to update these dependencies